### PR TITLE
Support verified music in Youtube

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ Update your profile with the song you are listening, using chrome extensions, in
 
 ## Supported Platforms
 
+- YouTube
 - Youtube Music
 - Soundcloud
 - Spotify

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     },
     "author": "20chan",
     "homepage_url": "https://github.com/20chan/github-now",
-    "permissions": ["tabs", "storage", "alarms", "https://github.com/*", "https://soundcloud.com/*", "https://music.youtube.com/*", "https://open.spotify.com/*"],
+    "permissions": ["tabs", "storage", "alarms", "https://github.com/*", "https://soundcloud.com/*", "https://music.youtube.com/*", "https://open.spotify.com/*", "https://www.youtube.com/*"],
     "content_scripts": [
       {
         "js": ["contentscript.js"],

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -186,8 +186,8 @@ const report = () => {
                     const res = results[0] as string[];
                     const verified = res[5];
                     if (verified === 'true') {
-                        const name = res[0];
                         const artists = res[1];
+                        const name = res[0].replace(artists + " - ", ""); // Remove artist from music title.
                         const albumCoverImage = res[2];
                         const url = res[3];
                         const liked = res[4] === 'true';

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -175,12 +175,12 @@ const report = () => {
             if (t.audible && t.url.startsWith('https://www.youtube.com/')) {
                 chrome.tabs.executeScript(t.id, {
                     code: `[
-                        document.querySelector('.title').innerText,
-                        document.querySelector('ytd-channel-name').innerText,
-                        document.querySelector('ytd-video-owner-renderer img').src,
-                        document.querySelector('ytd-video-owner-renderer a').href,
+                        document.querySelector('.title.ytd-video-primary-info-renderer').innerText,
+                        document.querySelector('ytd-video-secondary-info-renderer ytd-channel-name').innerText,
+                        document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer img').src,
+                        document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer a').href,
                         document.querySelector('ytd-video-primary-info-renderer yt-icon-button button')?.getAttribute('aria-pressed'),
-                        (!!document.querySelector('ytd-video-owner-renderer .badge-style-type-verified-artist')).toString(),
+                        (!!document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer .badge-style-type-verified-artist')).toString(),
                     ]`
                 }, results => {
                     const res = results[0] as string[];


### PR DESCRIPTION
현재 유튜브에서 재생 중인 영상이 [공식 아티스트 채널](https://support.google.com/youtube/answer/7336634)의 것인 페이지에 한해서 정보를 긁도록 했습니다.
특수한 알고리즘을 쓴 게 아니라서 완전히 거르진 못합니다.
(그냥 채널 이름 옆에 아티스트 뱃지(음표 모양)가 있는지 확인함.)

현재 읽을 수 있는 정보:
* 영상 제목
* 채널 이름
* 채널 이미지(원래는 영상 이미지를 얻어와야 하는데 방법을 찾아봐야 함.)
* 채널 링크(원래는 영상이나 앨범 링크를 얻어와야 하는데 방법을 찾아봐야 함.)
* 좋아요 여부
* 공식 아티스트 채널 여부

일반적인 단일 영상 페이지(/watch?v={v})랑 재생 목록이 있는 페이지(/watch?v={v}&list={list})에서 테스트되었고 다른 상황에선 Selector가 제대로 동작하지 않을 수 있습니다.

PR이랑 코드는 맘대로 해주십셔. 😉 