### PR TITLE
Get ytmusic current listening song url instead of main artist url

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -119,7 +119,7 @@ const report = () => {
                         document.querySelector('yt-formatted-string.ytmusic-player-bar.title').innerText,
                         document.querySelector('yt-formatted-string.ytmusic-player-bar.byline').title,
                         document.querySelector('img.ytmusic-player-bar').src,
-                        document.querySelector('.ytmusic-player-bar .yt-simple-endpoint')?.href,
+                        document.querySelector('.ytp-title-link').href,
                         document.querySelector('paper-icon-button.like').getAttribute('aria-pressed'),
                     ]`
                 }, results => {
@@ -129,7 +129,8 @@ const report = () => {
                     const [artists, album, year] = infos;
                     const albumCoverImgSrc = res[2];
                     const albumCoverImgOriginal = new RegExp('(.*)=.*').exec(albumCoverImgSrc)[1];
-                    const url = res[3] ?? `https://music.youtube.com/watch?v=${new RegExp('vi/(.*)/.*').exec(albumCoverImgSrc)[1]}`;
+                    const ytMediaUrl = res[3];
+                    const url = `https://music.youtube.com/watch?v=${new RegExp('.*=(.*)').exec(ytMediaUrl)[1]}`;
                     const liked = res[4] === 'true';
                     tryupdate({
                         src: 'YTMusic',


### PR DESCRIPTION
I test this with some songs, probably more testing is needed because of the complexity of some ytmusic html tags or you can try share a song, get the ID and search in the html.

Closes #10 