### PR TITLE
fix youtube display

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ts-node": "^8.10.2",
     "tslint": "^6.1.2",
     "typescript": "^3.9.6",
-    "webpack": "^4.42.0",
+    "webpack": "4.42.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {}

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -179,9 +179,9 @@ const report = () => {
                 chrome.tabs.executeScript(t.id, {
                     code: `[
                         document.querySelector('.title.ytd-video-primary-info-renderer').innerText,
-                        document.querySelector('ytd-video-secondary-info-renderer ytd-channel-name').innerText,
-                        document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer img').src,
-                        document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer a').href,
+                        document.querySelector('ytd-channel-name').innerText,
+                        document.querySelector('link[itemprop="thumbnailUrl"]').href,
+                        document.querySelector('link[rel="canonical"]').href,
                         document.querySelector('ytd-video-primary-info-renderer yt-icon-button button')?.getAttribute('aria-pressed'),
                         (!!document.querySelector('ytd-video-secondary-info-renderer ytd-video-owner-renderer .badge-style-type-verified-artist')).toString(),
                     ]`


### PR DESCRIPTION
It seems like some items are not returning what we expect for YouTube.

I fixed 3 of the selectors (seems like markup changes broke the previous selectors):

```
document.querySelector('ytd-channel-name').innerText,
document.querySelector('link[itemprop="thumbnailUrl"]').href,
document.querySelector('link[rel="canonical"]').href,
```

One thing that was changed is the item `href` now points to the video being shown rather than the channel home page. This seems more consistent (that's how SoundCloud works, etc.).

Broken:
![2021-12-18_01-38-01PM](https://user-images.githubusercontent.com/1605754/146678759-a0eb4123-7831-4bd9-8210-478f27b93700.png)

Fixed:
![2021-12-18_04-35-20PM](https://user-images.githubusercontent.com/1605754/146678764-9daf250e-66d7-42bc-9e2e-1053d1238e96.png)

To build:
```
git clone git@github.com:christianboyle/github-now.git
cd github-now
git checkout fix_youtube
yarn
yarn add webpack@4.42.0 (this was required to get the project to build)
cd src/options
yarn
cd ../../
npm run build:all
```
